### PR TITLE
Add lumitrace GitHub Action (setup/report) and self-PR demo workflow

### DIFF
--- a/action/build_check.rb
+++ b/action/build_check.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Convert a lumitrace JSON report into a GitHub "create a check run" payload,
+# printed as JSON on stdout.
+#
+#   build_check.rb <lumitrace.json> <head_sha> <root> [details_url]
+#
+# Annotation strategy (see the project plan): annotations are a *curated few*,
+# not every traced line. We surface uncovered changed lines first (most useful
+# in review), then a capped number of value highlights. The full data lives in
+# the summary table and, when configured, the details_url report.
+
+require "json"
+
+# GitHub accepts at most 50 annotations per check-run API request. We keep a
+# single request here; callers wanting more would PATCH additional batches.
+MAX_ANNOTATIONS = 50
+# Cap value highlights (one per line) shown in the summary.
+HIGHLIGHT_LIMIT = 10
+
+json_path, head_sha, root, details_url = ARGV
+if json_path.nil? || head_sha.nil? || root.nil?
+  abort "usage: build_check.rb <lumitrace.json> <head_sha> <root> [details_url]"
+end
+
+check_name = ENV.fetch("LUMITRACE_CHECK_NAME", "lumitrace")
+data = JSON.parse(File.read(json_path))
+events = data["events"] || []
+coverage = data["coverage"] || []
+
+root_prefix = "#{root.chomp("/")}/"
+relativize = lambda do |file|
+  file.start_with?(root_prefix) ? file.delete_prefix(root_prefix) : file
+end
+
+# Best-available value description for an event, across collect modes.
+value_of = lambda do |event|
+  if (v = event["last_value"])
+    "#{v["type"]} #{v["preview"]}"
+  elsif (vals = event["sampled_values"]) && !vals.empty?
+    last = vals.last
+    "#{last["type"]} #{last["preview"]}"
+  else
+    (event["types"] || {}).keys.join(" | ")
+  end
+end
+
+uncovered = events.select { |e| e["total"].to_i.zero? }
+covered = events.select { |e| e["total"].to_i.positive? }
+
+# Inline annotations are reserved for lines that need attention — currently
+# uncovered changed lines (total==0). Recorded values are deliberately NOT
+# annotated inline: a value on every changed line buries the diff. They live in
+# the summary highlights (Checks tab) and the full HTML report instead.
+seen_lines = {} # one annotation per (file, line)
+annotations = uncovered.filter_map do |e|
+  key = [e["file"], e["start_line"]]
+  next if seen_lines[key]
+
+  seen_lines[key] = true
+  {
+    "path" => relativize.call(e["file"]),
+    "start_line" => e["start_line"],
+    "end_line" => e["start_line"],
+    "annotation_level" => "warning",
+    "title" => "lumitrace: uncovered",
+    "message" => "This changed line was never executed in this run (total=0)."
+  }
+end
+
+annotations_truncated = annotations.size > MAX_ANNOTATIONS
+annotations = annotations.first(MAX_ANNOTATIONS)
+
+# Value highlights for the summary only (Checks tab, never inline on the diff).
+# One representative value per changed line: the outermost expression — the one
+# starting earliest on the line, widest on ties — so nested sub-expressions
+# don't repeat a line. Keeps the summary compact.
+by_line = {}
+covered.each do |e|
+  key = [e["file"], e["start_line"]]
+  cur = by_line[key]
+  better =
+    cur.nil? ||
+    e["start_col"].to_i < cur["start_col"].to_i ||
+    (e["start_col"].to_i == cur["start_col"].to_i &&
+     ([e["end_line"].to_i, e["end_col"].to_i] <=> [cur["end_line"].to_i, cur["end_col"].to_i]) > 0)
+  by_line[key] = e if better
+end
+all_highlights = by_line.values.sort_by { |e| [relativize.call(e["file"]), e["start_line"]] }
+highlights = all_highlights.first(HIGHLIGHT_LIMIT)
+highlights_truncated = all_highlights.size > HIGHLIGHT_LIMIT
+
+# Summary markdown.
+summary = +"**Lumitrace** traced #{events.size} expression(s) in the changed range.\n\n"
+unless coverage.empty?
+  summary << "| File | Covered | % |\n|---|---|---|\n"
+  coverage.each do |c|
+    summary << "| `#{relativize.call(c["file"])}` | " \
+               "#{c["covered_lines"]}/#{c["total_lines"]} | #{c["coverage_percent"]}% |\n"
+  end
+end
+summary << "\n⚠️ #{uncovered.size} changed line(s) never executed.\n" unless uncovered.empty?
+summary << "\n_Showing the first #{MAX_ANNOTATIONS} of #{uncovered.size} uncovered annotations._\n" if annotations_truncated
+unless highlights.empty?
+  summary << "\n**Highlights**\n"
+  highlights.each do |e|
+    loc = "#{relativize.call(e["file"])}:#{e["start_line"]}"
+    name = e["name"] ? "`#{e["name"]}` " : ""
+    summary << "- `#{loc}` #{name}→ #{value_of.call(e)}\n"
+  end
+  summary << "- …and #{all_highlights.size - HIGHLIGHT_LIMIT} more\n" if highlights_truncated
+end
+summary << "\n[Full report ↗](#{details_url})\n" if details_url && !details_url.empty?
+
+title =
+  if uncovered.empty?
+    "#{events.size} expressions traced"
+  else
+    "#{uncovered.size} uncovered · #{events.size} traced"
+  end
+
+payload = {
+  "name" => check_name,
+  "head_sha" => head_sha,
+  "status" => "completed",
+  # Informational only: never block CI on a trace.
+  "conclusion" => "neutral",
+  "output" => {
+    "title" => title,
+    "summary" => summary,
+    "annotations" => annotations
+  }
+}
+payload["details_url"] = details_url if details_url && !details_url.empty?
+
+puts JSON.pretty_generate(payload)

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -1,0 +1,59 @@
+name: Lumitrace Report
+description: >-
+  Turn the lumitrace JSON output into a GitHub Check Run (summary + diff-line
+  annotations). Optionally uploads the JSON to a backend for a full HTML report.
+  Works with no backend: leave `endpoint` empty and the check is still posted
+  via the workflow GITHUB_TOKEN (needs `permissions: checks: write`).
+inputs:
+  output:
+    description: "JSON path (must match the setup action's `output`)."
+    default: "lumitrace.json"
+  name:
+    description: "Check run name shown on the PR."
+    default: "lumitrace"
+  endpoint:
+    description: "Backend base URL to upload the JSON to. Empty = skip upload (no server needed)."
+    default: ""
+  audience:
+    description: "OIDC audience for the upload (only used when endpoint is set)."
+    default: "lumitrace-ci"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        LUMITRACE_CHECK_NAME: ${{ inputs.name }}
+      run: |
+        set -euo pipefail
+
+        OUT="${{ inputs.output }}"
+        if [ ! -s "$OUT" ]; then
+          echo "lumitrace: no trace output at $OUT (diff had no traced lines?) — skipping check."
+          exit 0
+        fi
+
+        HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+        [ -z "$HEAD_SHA" ] && HEAD_SHA="${{ github.sha }}"
+
+        # Optional upload to the backend, authenticated with the job's OIDC token (no shared secret).
+        DETAILS=""
+        if [ -n "${{ inputs.endpoint }}" ]; then
+          OIDC="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+                  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" \
+                  | ruby -rjson -e 'puts JSON.parse(STDIN.read)["value"]')"
+          DETAILS="$(curl -sS -X POST "${{ inputs.endpoint }}/api/uploads" \
+                  -H "Authorization: Bearer $OIDC" \
+                  -F "repo=${{ github.repository }}" \
+                  -F "sha=${HEAD_SHA}" \
+                  -F "pr=${{ github.event.pull_request.number }}" \
+                  -F "json=@${OUT}" \
+                  | ruby -rjson -e 'begin; puts JSON.parse(STDIN.read)["report_url"]; rescue; end')"
+        fi
+
+        ruby "$GITHUB_ACTION_PATH/../build_check.rb" \
+          "$OUT" "$HEAD_SHA" "${{ github.workspace }}" "$DETAILS" > "$RUNNER_TEMP/lumitrace-check.json"
+
+        gh api "repos/${{ github.repository }}/check-runs" \
+          --input "$RUNNER_TEMP/lumitrace-check.json" --silent
+        echo "lumitrace: posted check run '${{ inputs.name }}' for ${HEAD_SHA}"

--- a/action/setup/action.yml
+++ b/action/setup/action.yml
@@ -1,0 +1,62 @@
+name: Lumitrace Setup
+description: >-
+  Enable lumitrace for the steps that follow by injecting env vars into
+  $GITHUB_ENV. The existing test step gets traced (diff range only) without
+  changing its command. Uses the lumitrace gem source shipped with this action
+  checkout, so no `gem install` is needed.
+inputs:
+  collect-mode:
+    description: "last | types | history (default types: keeps raw values out of the public PR view)"
+    default: "types"
+  output:
+    description: "Path for the JSON trace output (must match the report action's `output`)."
+    default: "lumitrace.json"
+  diff:
+    description: >-
+      LUMITRACE_GIT_DIFF value (working | staged | base:REV | range:SPEC).
+      Empty = derive from the event (PR base sha, else push `before`, else `working`).
+    default: ""
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+
+        # action/setup -> ../.. == the gem repo root that GitHub checked out for this action.
+        LUMI_LIB="$(cd "$GITHUB_ACTION_PATH/../.." && pwd)/lib"
+        if [ ! -f "$LUMI_LIB/lumitrace.rb" ]; then
+          echo "::error::lumitrace lib not found at $LUMI_LIB" >&2
+          exit 1
+        fi
+
+        # Fail-safe: tracing must never break the user's test step. If lumitrace
+        # can't even load on this Ruby, warn and skip injecting RUBYOPT so the
+        # following steps run exactly as they would without this action.
+        if ! err="$(ruby -I"$LUMI_LIB" -e 'require "lumitrace"' 2>&1)"; then
+          echo "::warning title=lumitrace::tracing disabled — lumitrace failed to load: ${err##*$'\n'}"
+          exit 0
+        fi
+
+        DIFF="${{ inputs.diff }}"
+        if [ -z "$DIFF" ]; then
+          BASE="${{ github.event.pull_request.base.sha }}"
+          [ -z "$BASE" ] && BASE="${{ github.event.before }}"
+          if [ -n "$BASE" ] && [ "$BASE" != "0000000000000000000000000000000000000000" ]; then
+            DIFF="base:${BASE}"
+          else
+            DIFF="working"
+          fi
+        fi
+
+        {
+          echo "RUBYLIB=${LUMI_LIB}${RUBYLIB:+:$RUBYLIB}"
+          echo "RUBYOPT=-rlumitrace ${RUBYOPT:-}"
+          echo "LUMITRACE_ENABLE=1"
+          echo "LUMITRACE_JSON=${{ inputs.output }}"
+          echo "LUMITRACE_ROOT=${{ github.workspace }}"
+          echo "LUMITRACE_COLLECT_MODE=${{ inputs.collect-mode }}"
+          echo "LUMITRACE_GIT_DIFF=${DIFF}"
+        } >> "$GITHUB_ENV"
+
+        echo "lumitrace enabled: mode=${{ inputs.collect-mode }} diff=${DIFF} out=${{ inputs.output }} lib=${LUMI_LIB}"


### PR DESCRIPTION
Trace a PR's diff range during the test run and post a GitHub Check Run with a coverage summary and curated annotations. Activation is env-driven: the setup action injects RUBYOPT=-rlumitrace + LUMITRACE_* into $GITHUB_ENV (using the gem source shipped with the action checkout, no gem install), so the existing test step is traced without changing its command. The report action builds the check payload (action/build_check.rb) and posts it via the workflow GITHUB_TOKEN; backend upload is optional (no server/App required).


Claude-Session: https://claude.ai/code/session_01Ers2PzFfbJNNsnBV4HpVJL