### PR TITLE
Fix Ruby 3.4-only Prism node crash and make env auto-enable fail-safe

### DIFF
--- a/lib/lumitrace.rb
+++ b/lib/lumitrace.rb
@@ -568,18 +568,27 @@ module Lumitrace
 end
 
 enable_env = Lumitrace.parse_env_flag(ENV["LUMITRACE_ENABLE"])
-if enable_env == true
-  Lumitrace.enable!
-elsif enable_env.is_a?(String)
-  opts = Lumitrace.parse_enable_args(enable_env)
-  Lumitrace.enable!(
-    max_samples: opts[:max_samples],
-    ranges_by_file: opts[:ranges_by_file],
-    root: opts[:root],
-    text: opts[:text],
-    html: opts[:html],
-    json: opts[:json],
-    verbose: opts[:verbose],
-    collect_mode: opts[:collect_mode]
-  )
+if enable_env
+  begin
+    if enable_env == true
+      Lumitrace.enable!
+    elsif enable_env.is_a?(String)
+      opts = Lumitrace.parse_enable_args(enable_env)
+      Lumitrace.enable!(
+        max_samples: opts[:max_samples],
+        ranges_by_file: opts[:ranges_by_file],
+        root: opts[:root],
+        text: opts[:text],
+        html: opts[:html],
+        json: opts[:json],
+        verbose: opts[:verbose],
+        collect_mode: opts[:collect_mode]
+      )
+    end
+  rescue ScriptError, StandardError => e
+    # Fail-safe: tracing was auto-enabled via env (e.g. RUBYOPT=-rlumitrace in CI).
+    # A failure here must never take down the host process / test run — disable
+    # tracing and carry on. (Explicit Lumitrace.enable! calls still raise.)
+    warn "lumitrace: tracing disabled (enable failed: #{e.class}: #{e.message})"
+  end
 end

--- a/lib/lumitrace/record_instrument.rb
+++ b/lib/lumitrace/record_instrument.rb
@@ -42,12 +42,15 @@ module RecordInstrument
     Prism::CallNode,
     Prism::YieldNode,
     Prism::LocalVariableReadNode,
-    Prism::ItLocalVariableReadNode,
     Prism::ConstantReadNode,
     Prism::InstanceVariableReadNode,
     Prism::ClassVariableReadNode,
-    Prism::GlobalVariableReadNode
-  ].freeze
+    Prism::GlobalVariableReadNode,
+    # `it` implicit block parameter: the Prism node exists only on Ruby 3.4+.
+    # Guard it so requiring lumitrace doesn't raise on the declared 3.2/3.3 floor
+    # (those Rubies have no `it` to trace anyway).
+    (Prism::ItLocalVariableReadNode if defined?(Prism::ItLocalVariableReadNode))
+  ].compact.freeze
 
   def self.instrument_source(src, ranges, file_label: nil, record_method: "::Lumitrace::R")
     file_label ||= "(unknown)"

--- a/test/test_lumitrace.rb
+++ b/test/test_lumitrace.rb
@@ -50,6 +50,37 @@ class LumiTraceTest < Minitest::Test
     assert defined?(Lumitrace::GenerateResultedHtml)
   end
 
+  # Regression: WRAP_NODE_CLASSES must contain only real classes. Prism nodes
+  # that exist on newer Rubies only (e.g. Prism::ItLocalVariableReadNode, 3.4+)
+  # are guarded with `if defined?` + compact, so a missing constant must not
+  # leak a nil (which would also break requiring lumitrace on the 3.2/3.3 floor).
+  def test_wrap_node_classes_are_all_classes
+    classes = Lumitrace::RecordInstrument::WRAP_NODE_CLASSES
+    assert classes.frozen?
+    refute_empty classes
+    assert(classes.all? { |c| c.is_a?(Class) }, "WRAP_NODE_CLASSES must not contain nil")
+  end
+
+  # Regression: tracing auto-enabled via env (RUBYOPT=-rlumitrace in CI) must
+  # never take down the host process if enable! fails. An invalid LUMITRACE_RANGE
+  # makes enable! raise ArgumentError; the host program must still run and exit 0.
+  def test_env_auto_enable_failure_does_not_crash_host
+    lib = File.expand_path("../lib", __dir__)
+    env = {
+      "RUBYLIB" => lib,
+      "RUBYOPT" => "-rlumitrace",
+      "LUMITRACE_ENABLE" => "1",
+      "LUMITRACE_RANGE" => ":", # invalid spec -> enable! raises ArgumentError
+      "LUMITRACE_TEXT" => "0",
+      "LUMITRACE_HTML" => "0",
+      "LUMITRACE_JSON" => "0"
+    }
+    out = IO.popen(env, [RbConfig.ruby, "-e", 'print "HOST_OK"'], err: %i[child out], &:read)
+    assert_equal 0, $?.exitstatus, "auto-enable failure must not crash the host: #{out}"
+    assert_includes out, "HOST_OK"
+    assert_includes out, "tracing disabled"
+  end
+
   def test_instrument_wraps_calls_and_reads
     src = <<~RUBY
       def compute(x)


### PR DESCRIPTION
Two bugs surfaced by running the gem under CI on Ruby 3.3:

1. record_instrument.rb referenced Prism::ItLocalVariableReadNode unconditionally, but that node exists only on Ruby 3.4+. Requiring lumitrace raised NameError on the declared 3.2/3.3 floor (and `it` does not exist there to trace anyway). Guard it with `if defined?` + compact.

2. When tracing is auto-enabled via env (RUBYOPT=-rlumitrace, e.g. in CI), a failure in enable\! took down the host process — i.e. the user's test step. Wrap the env-driven auto-enable in a rescue so a failure disables tracing with a warning instead of crashing. Explicit Lumitrace.enable\! calls still raise.

Add regression tests for both (WRAP_NODE_CLASSES has no nil; an invalid LUMITRACE_RANGE under env auto-enable still exits 0 and runs host code).


Claude-Session: https://claude.ai/code/session_01Ers2PzFfbJNNsnBV4HpVJL