### PR TITLE
Defer require of json and prism so RUBYOPT injection is bundler-safe

### DIFF
--- a/lib/lumitrace.rb
+++ b/lib/lumitrace.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "shellwords"
 require "tmpdir"
 require_relative "lumitrace/version"

--- a/lib/lumitrace/ai_docs.rb
+++ b/lib/lumitrace/ai_docs.rb
@@ -13,6 +13,7 @@ module Lumitrace
   end
 
   def self.render_help(format: "text")
+    require "json"
     normalized = normalize_output_format(format)
     data = help_manifest
     return JSON.pretty_generate(data) + "\n" if normalized == "json"
@@ -63,6 +64,7 @@ module Lumitrace
   end
 
   def self.render_schema(format: "text")
+    require "json"
     normalized = normalize_output_format(format)
     data = schema_manifest
     return JSON.pretty_generate(data) + "\n" if normalized == "json"

--- a/lib/lumitrace/generate_resulted_html.rb
+++ b/lib/lumitrace/generate_resulted_html.rb
@@ -1,4 +1,4 @@
-require "json"
+# `require "json"` is deferred to the methods that use it; see record_instrument.rb.
 require_relative "record_instrument"
 
 module Lumitrace
@@ -18,6 +18,7 @@ module GenerateResultedHtml
   end
 
   def self.render(source_path, events_path, ranges: nil, collect_mode: nil, max_samples: nil)
+    require "json"
     unless File.exist?(events_path)
       abort "missing #{events_path}"
     end
@@ -116,6 +117,7 @@ module GenerateResultedHtml
   end
 
   def self.payload_json_for_script(payload)
+    require "json"
     JSON.generate(payload)
       .gsub("</", "<\\/")
       .gsub("\u2028", "\\u2028")
@@ -676,6 +678,7 @@ module GenerateResultedHtml
   end
 
   def self.render_all(events_path, root: Dir.pwd, ranges_by_file: nil, collect_mode: nil, max_samples: nil, logger: nil, command_text: nil)
+    require "json"
     raw = JSON.parse(File.read(events_path))
     raw_events = raw.is_a?(Hash) && raw.key?("events") ? raw["events"] : raw
     render_all_from_events(

--- a/lib/lumitrace/record_instrument.rb
+++ b/lib/lumitrace/record_instrument.rb
@@ -1,5 +1,10 @@
-require "json"
-require "prism"
+# NOTE: `require "json"` and `require "prism"` are deliberately deferred to the
+# methods that use them. lumitrace is loaded via `RUBYOPT=-rlumitrace`, i.e.
+# before Bundler sets up the load path; requiring a default gem (json, prism) at
+# that point activates the default version and conflicts with apps whose bundle
+# pins a different one. The translate hook only parses (needs prism) for files in
+# the diff range — which load after Bundler — and json is used only at output
+# time, so both are required lazily (see the node-class tables and json sites).
 
 module Lumitrace
   def self.R(id, value)
@@ -9,50 +14,41 @@ module Lumitrace
 module RecordInstrument
   IDENTIFIER_METHOD_NAME_RE = /\A[a-z_]\w*[!?=]?\z/.freeze
 
-  SKIP_NODE_CLASSES = [
-    Prism::DefNode,
-    Prism::ClassNode,
-    Prism::ModuleNode,
-    Prism::IfNode,
-    Prism::UnlessNode,
-    Prism::WhileNode,
-    Prism::UntilNode,
-    Prism::ForNode,
-    Prism::CaseNode,
-    Prism::BeginNode,
-    Prism::RescueNode,
-    Prism::EnsureNode,
-    Prism::AliasMethodNode,
-    Prism::UndefNode
-  ].freeze
+  # Node-class tables are built lazily (memoized) so they don't reference Prism
+  # at load time — only on first instrumentation, after `require "prism"`.
+  def self.skip_node_classes
+    require "prism"
+    @skip_node_classes ||= [
+      Prism::DefNode, Prism::ClassNode, Prism::ModuleNode, Prism::IfNode,
+      Prism::UnlessNode, Prism::WhileNode, Prism::UntilNode, Prism::ForNode,
+      Prism::CaseNode, Prism::BeginNode, Prism::RescueNode, Prism::EnsureNode,
+      Prism::AliasMethodNode, Prism::UndefNode
+    ].freeze
+  end
 
-  LITERAL_NODE_CLASSES = [
-    Prism::IntegerNode,
-    Prism::FloatNode,
-    Prism::RationalNode,
-    Prism::ImaginaryNode,
-    Prism::StringNode,
-    Prism::SymbolNode,
-    Prism::TrueNode,
-    Prism::FalseNode,
-    Prism::NilNode
-  ].freeze
+  def self.literal_node_classes
+    require "prism"
+    @literal_node_classes ||= [
+      Prism::IntegerNode, Prism::FloatNode, Prism::RationalNode,
+      Prism::ImaginaryNode, Prism::StringNode, Prism::SymbolNode,
+      Prism::TrueNode, Prism::FalseNode, Prism::NilNode
+    ].freeze
+  end
 
-  WRAP_NODE_CLASSES = [
-    Prism::CallNode,
-    Prism::YieldNode,
-    Prism::LocalVariableReadNode,
-    Prism::ConstantReadNode,
-    Prism::InstanceVariableReadNode,
-    Prism::ClassVariableReadNode,
-    Prism::GlobalVariableReadNode,
-    # `it` implicit block parameter: the Prism node exists only on Ruby 3.4+.
-    # Guard it so requiring lumitrace doesn't raise on the declared 3.2/3.3 floor
-    # (those Rubies have no `it` to trace anyway).
-    (Prism::ItLocalVariableReadNode if defined?(Prism::ItLocalVariableReadNode))
-  ].compact.freeze
+  def self.wrap_node_classes
+    require "prism"
+    @wrap_node_classes ||= [
+      Prism::CallNode, Prism::YieldNode, Prism::LocalVariableReadNode,
+      Prism::ConstantReadNode, Prism::InstanceVariableReadNode,
+      Prism::ClassVariableReadNode, Prism::GlobalVariableReadNode,
+      # `it` implicit block parameter: the Prism node exists only on Ruby 3.4+.
+      # Guard it so older Rubies (no `it` to trace) don't raise.
+      (Prism::ItLocalVariableReadNode if defined?(Prism::ItLocalVariableReadNode))
+    ].compact.freeze
+  end
 
   def self.instrument_source(src, ranges, file_label: nil, record_method: "::Lumitrace::R")
+    require "prism"
     file_label ||= "(unknown)"
     ranges = normalize_ranges(ranges)
 
@@ -74,6 +70,7 @@ module RecordInstrument
   end
 
   def self.collect_locations_from_source(src, ranges)
+    require "prism"
     ranges = normalize_ranges(ranges || [])
     parse = Prism.parse(src)
     if parse.errors.any?
@@ -176,7 +173,7 @@ module RecordInstrument
   end
 
   def self.literal_value_node?(node)
-    LITERAL_NODE_CLASSES.include?(node.class)
+    literal_node_classes.include?(node.class)
   end
 
   def self.wrap_expr?(node, parent = nil)
@@ -200,7 +197,7 @@ module RecordInstrument
        (parent.is_a?(Prism::ClassNode) || parent.is_a?(Prism::ModuleNode))
       return false
     end
-    WRAP_NODE_CLASSES.include?(node.class)
+    wrap_node_classes.include?(node.class)
   end
 
   def self.command_style_call_node?(node)
@@ -491,12 +488,14 @@ module RecordInstrument
   end
 
   def self.dump_json(path = nil)
+    require "json"
     path ||= File.expand_path("lumitrace_recorded.json", Dir.pwd)
     File.write(path, JSON.dump(events_from_ids), perm: 0o600)
     path
   end
 
   def self.dump_events_json(events, path = nil)
+    require "json"
     path ||= File.expand_path("lumitrace_recorded.json", Dir.pwd)
     payload = {
       version: 1,
@@ -535,6 +534,7 @@ module RecordInstrument
   end
 
   def self.load_events_json(path)
+    require "json"
     JSON.parse(File.read(path))
   end
 
@@ -766,6 +766,7 @@ module RecordInstrument
   end
 
   def self.definition_lines_from_source(src, ranges)
+    require "prism"
     ranges = normalize_ranges(ranges || [])
     parse = Prism.parse(src)
     if parse.errors.any?
@@ -938,6 +939,7 @@ end
 end
 
 if $PROGRAM_NAME == __FILE__
+  require "json"
   path = ARGV[0] or abort "usage: ruby record_instrument.rb FILE RANGES_JSON [record_method] [out_path]"
   ranges = JSON.parse(ARGV[1] || "[]")
   record_method = ARGV[2] || "Lumitrace::R"

--- a/lib/lumitrace/record_require.rb
+++ b/lib/lumitrace/record_require.rb
@@ -1,5 +1,5 @@
-require "json"
-require "prism"
+# `require "prism"` is deferred to RecordInstrument's parse methods (loaded only
+# when instrumenting an in-range file, after Bundler). See record_instrument.rb.
 require_relative "./record_instrument"
 
 module Lumitrace

--- a/test/test_lumitrace.rb
+++ b/test/test_lumitrace.rb
@@ -50,15 +50,15 @@ class LumiTraceTest < Minitest::Test
     assert defined?(Lumitrace::GenerateResultedHtml)
   end
 
-  # Regression: WRAP_NODE_CLASSES must contain only real classes. Prism nodes
+  # Regression: wrap_node_classes must contain only real classes. Prism nodes
   # that exist on newer Rubies only (e.g. Prism::ItLocalVariableReadNode, 3.4+)
   # are guarded with `if defined?` + compact, so a missing constant must not
   # leak a nil (which would also break requiring lumitrace on the 3.2/3.3 floor).
   def test_wrap_node_classes_are_all_classes
-    classes = Lumitrace::RecordInstrument::WRAP_NODE_CLASSES
+    classes = Lumitrace::RecordInstrument.wrap_node_classes
     assert classes.frozen?
     refute_empty classes
-    assert(classes.all? { |c| c.is_a?(Class) }, "WRAP_NODE_CLASSES must not contain nil")
+    assert(classes.all? { |c| c.is_a?(Class) }, "wrap_node_classes must not contain nil")
   end
 
   # Regression: tracing auto-enabled via env (RUBYOPT=-rlumitrace in CI) must


### PR DESCRIPTION
lumitrace is loaded via RUBYOPT=-rlumitrace, i.e. before Bundler sets up the load path. Eagerly requiring a default gem (json, prism) at that point activates the default version and conflicts with apps whose bundle pins a different one — e.g. a Rails app whose lock has json 2.19.9 / prism 1.9.0, which fails at bundler/setup with "already activated ... but Gemfile requires".

- json: required lazily in the methods that dump/parse/render (all run at output time, after Bundler).
- prism: the node-class tables (WRAP/LITERAL/SKIP) become lazy memoized methods so they no longer reference Prism at load; require "prism" is added to the three Prism.parse entry points. The translate hook already returns out-of-range files before instrumenting, so prism is loaded only when an in-range (diff) file is compiled — after Bundler — using the bundle's pinned version.

Verified: requiring lumitrace loads neither json nor prism; requiring bundler/setup (which fires the hook on bundler's own files) does not load prism; full suite and a sample trace still pass.