### PR TITLE
action: upload self-contained HTML + JSON to the report backend

### DIFF
--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -8,11 +8,14 @@ inputs:
   output:
     description: "JSON path (must match the setup action's `output`)."
     default: "lumitrace.json"
+  html:
+    description: "HTML path (must match the setup action's `html`); uploaded when `endpoint` is set."
+    default: "lumitrace.html"
   name:
     description: "Check run name shown on the PR."
     default: "lumitrace"
   endpoint:
-    description: "Backend base URL to upload the JSON to. Empty = skip upload (no server needed)."
+    description: "Backend base URL to upload the report to (e.g. https://lumitrace.atdot.net). Empty = skip upload (no server needed)."
     default: ""
   audience:
     description: "OIDC audience for the upload (only used when endpoint is set)."
@@ -36,19 +39,25 @@ runs:
         HEAD_SHA="${{ github.event.pull_request.head.sha }}"
         [ -z "$HEAD_SHA" ] && HEAD_SHA="${{ github.sha }}"
 
-        # Optional upload to the backend, authenticated with the job's OIDC token (no shared secret).
+        # Optional upload to the backend, authenticated with the job's OIDC token
+        # (no shared secret). The server derives repo/sha/visibility from the OIDC
+        # claims; we send the trace JSON and the self-contained HTML, and use the
+        # returned view_url (a path) as the check's details link.
         DETAILS=""
-        if [ -n "${{ inputs.endpoint }}" ]; then
+        ENDPOINT="${{ inputs.endpoint }}"
+        if [ -n "$ENDPOINT" ]; then
+          ENDPOINT="${ENDPOINT%/}"
           OIDC="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
                   "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" \
                   | ruby -rjson -e 'puts JSON.parse(STDIN.read)["value"]')"
-          DETAILS="$(curl -sS -X POST "${{ inputs.endpoint }}/api/uploads" \
+          HTML="${{ inputs.html }}"
+          html_field=()
+          [ -s "$HTML" ] && html_field=(-F "html=@${HTML}")
+          VIEW="$(curl -sS -X POST "${ENDPOINT}/api/v1/upload" \
                   -H "Authorization: Bearer $OIDC" \
-                  -F "repo=${{ github.repository }}" \
-                  -F "sha=${HEAD_SHA}" \
-                  -F "pr=${{ github.event.pull_request.number }}" \
-                  -F "json=@${OUT}" \
-                  | ruby -rjson -e 'begin; puts JSON.parse(STDIN.read)["report_url"]; rescue; end')"
+                  -F "json=@${OUT}" "${html_field[@]}" \
+                  | ruby -rjson -e 'begin; puts JSON.parse(STDIN.read)["view_url"]; rescue; end')"
+          [ -n "$VIEW" ] && DETAILS="${ENDPOINT}${VIEW}"
         fi
 
         ruby "$GITHUB_ACTION_PATH/../build_check.rb" \

--- a/action/setup/action.yml
+++ b/action/setup/action.yml
@@ -12,6 +12,9 @@ inputs:
   output:
     description: "Path for the JSON trace output (must match the report action's `output`)."
     default: "lumitrace.json"
+  html:
+    description: "Path for the self-contained HTML report (uploaded by the report action when a backend is set)."
+    default: "lumitrace.html"
   diff:
     description: >-
       LUMITRACE_GIT_DIFF value (working | staged | base:REV | range:SPEC).
@@ -70,6 +73,7 @@ runs:
           echo "RUBYOPT=-rlumitrace ${RUBYOPT:-}"
           echo "LUMITRACE_ENABLE=1"
           echo "LUMITRACE_JSON=${{ inputs.output }}"
+          echo "LUMITRACE_HTML=${{ inputs.html }}"
           echo "LUMITRACE_ROOT=${{ github.workspace }}"
           echo "LUMITRACE_COLLECT_MODE=${{ inputs.collect-mode }}"
           echo "LUMITRACE_GIT_DIFF=${DIFF}"


### PR DESCRIPTION
setup now also emits the HTML report (LUMITRACE_HTML), and report uploads both
the JSON and the HTML to <endpoint>/api/v1/upload (OIDC-authenticated). The
server derives repo/sha/visibility from the OIDC claims, so we only send the
two artifacts and use the returned view_url (a path) as the check's details_url.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
