### PR TITLE
report: default endpoint + don't clobber trace output

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -21,8 +21,9 @@ name: test
 on: pull_request
 
 permissions:
-  checks: write     # required to post the check run
+  checks: write     # post the check run
   contents: read
+  id-token: write   # upload the report to lumitrace.atdot.net for a linked HTML report
 
 jobs:
   test:
@@ -41,7 +42,9 @@ jobs:
         if: always()                        # report even when tests fail
 ```
 
-That's the whole integration: two steps plus a `permissions:` block.
+That's the whole integration: two steps plus a `permissions:` block. Drop
+`id-token: write` and you still get the PR check — just without the linked
+hosted report (nothing is uploaded anywhere).
 
 ## What you get
 
@@ -68,8 +71,9 @@ That's the whole integration: two steps plus a `permissions:` block.
 |---|---|---|
 | `output` | `lumitrace.json` | JSON path (must match `setup`'s `output`). |
 | `name` | `lumitrace` | Check run name shown on the PR. |
-| `endpoint` | _(empty)_ | Backend base URL to upload the JSON to. Empty = skip upload (no server needed). |
-| `audience` | `lumitrace-ci` | OIDC audience for the upload (only used when `endpoint` is set). |
+| `html` | `lumitrace.html` | HTML path (must match `setup`'s `html`); uploaded with the JSON. |
+| `endpoint` | `https://lumitrace.atdot.net` | Backend the report is uploaded to. Upload only happens when the workflow grants `id-token: write`; set to `""` to disable, or point at your own server. |
+| `audience` | `lumitrace-ci` | OIDC audience for the upload. |
 
 ## Notes
 
@@ -80,9 +84,10 @@ That's the whole integration: two steps plus a `permissions:` block.
   checkout works. (If you set `persist-credentials: false`, add `fetch-depth: 0`.)
 - **Fail-safe.** If lumitrace can't load on the runner's Ruby, `setup` warns and
   skips injection — your test step runs exactly as it would without this action.
-- **No backend or App needed.** `report` posts the check with the workflow
-  `GITHUB_TOKEN`. Set `endpoint` (and `permissions: id-token: write`) only when you
-  add a backend for the full HTML report.
+- **Hosted report is opt-in via `id-token: write`.** With that permission, `report`
+  uploads to `lumitrace.atdot.net` (OIDC-authenticated, no shared secret) and links
+  the check to the HTML report. Without it, nothing is uploaded — you just get the
+  check, posted with the workflow `GITHUB_TOKEN`. Any upload failure is non-fatal.
 - **Fork PRs.** `GITHUB_TOKEN` is read-only on PRs from forks, so the check can't
   be posted there until a GitHub App is added.
 

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -15,8 +15,11 @@ inputs:
     description: "Check run name shown on the PR."
     default: "lumitrace"
   endpoint:
-    description: "Backend base URL to upload the report to (e.g. https://lumitrace.atdot.net). Empty = skip upload (no server needed)."
-    default: ""
+    description: >-
+      Backend the report is uploaded to (for the linked HTML report). Defaults to
+      the hosted lumitrace.atdot.net. Upload only happens when the workflow grants
+      `id-token: write`; set to "" to disable, or point at your own server.
+    default: "https://lumitrace.atdot.net"
   audience:
     description: "OIDC audience for the upload (only used when endpoint is set)."
     default: "lumitrace-ci"
@@ -39,25 +42,27 @@ runs:
         HEAD_SHA="${{ github.event.pull_request.head.sha }}"
         [ -z "$HEAD_SHA" ] && HEAD_SHA="${{ github.sha }}"
 
-        # Optional upload to the backend, authenticated with the job's OIDC token
-        # (no shared secret). The server derives repo/sha/visibility from the OIDC
-        # claims; we send the trace JSON and the self-contained HTML, and use the
-        # returned view_url (a path) as the check's details link.
+        # Upload to the backend (default lumitrace.atdot.net) ONLY when an OIDC
+        # token is available — i.e. the workflow granted `id-token: write`. No
+        # token, no endpoint, or any failure just means no hosted-report link:
+        # this never fails the job (lumitrace never blocks CI).
         DETAILS=""
         ENDPOINT="${{ inputs.endpoint }}"
-        if [ -n "$ENDPOINT" ]; then
-          ENDPOINT="${ENDPOINT%/}"
+        ENDPOINT="${ENDPOINT%/}"
+        if [ -n "$ENDPOINT" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
           OIDC="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-                  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" \
-                  | ruby -rjson -e 'puts JSON.parse(STDIN.read)["value"]')"
-          HTML="${{ inputs.html }}"
-          html_field=()
-          [ -s "$HTML" ] && html_field=(-F "html=@${HTML}")
-          VIEW="$(curl -sS -X POST "${ENDPOINT}/api/v1/upload" \
-                  -H "Authorization: Bearer $OIDC" \
-                  -F "json=@${OUT}" "${html_field[@]}" \
-                  | ruby -rjson -e 'begin; puts JSON.parse(STDIN.read)["view_url"]; rescue; end')"
-          [ -n "$VIEW" ] && DETAILS="${ENDPOINT}${VIEW}"
+                  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" 2>/dev/null \
+                  | ruby -rjson -e 'begin; print JSON.parse(STDIN.read)["value"]; rescue; end' || true)"
+          if [ -n "$OIDC" ]; then
+            HTML="${{ inputs.html }}"
+            html_field=()
+            [ -s "$HTML" ] && html_field=(-F "html=@${HTML}")
+            VIEW="$(curl -sS -X POST "${ENDPOINT}/api/v1/upload" \
+                    -H "Authorization: Bearer $OIDC" \
+                    -F "json=@${OUT}" "${html_field[@]}" 2>/dev/null \
+                    | ruby -rjson -e 'begin; print JSON.parse(STDIN.read)["view_url"]; rescue; end' || true)"
+            [ -n "$VIEW" ] && DETAILS="${ENDPOINT}${VIEW}"
+          fi
         fi
 
         ruby "$GITHUB_ACTION_PATH/../build_check.rb" \

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -33,6 +33,14 @@ runs:
       run: |
         set -euo pipefail
 
+        # setup left lumitrace active in the env (RUBYOPT=-rlumitrace + LUMITRACE_*).
+        # Turn it OFF here: otherwise the ruby we run below (build_check.rb, the
+        # OIDC parsing) would re-trace and OVERWRITE the test's output file with an
+        # empty result before we read/upload it.
+        unset RUBYOPT RUBYLIB LUMITRACE_ENABLE LUMITRACE_JSON LUMITRACE_HTML \
+              LUMITRACE_TEXT LUMITRACE_GIT_DIFF LUMITRACE_RANGE LUMITRACE_ROOT \
+              LUMITRACE_COLLECT_MODE LUMITRACE_MAX_SAMPLES LUMITRACE_VERBOSE
+
         OUT="${{ inputs.output }}"
         if [ ! -s "$OUT" ]; then
           echo "lumitrace: no trace output at $OUT (diff had no traced lines?) — skipping check."


### PR DESCRIPTION
- **action/report: default endpoint to lumitrace.atdot.net, upload only with id-token**
- **action/report: unset lumitrace env before running ruby (don't clobber the output)**
