### PR TITLE
Combine traces across steps; default endpoint; gzip upload

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -21,8 +21,9 @@ name: test
 on: pull_request
 
 permissions:
-  checks: write     # required to post the check run
+  checks: write     # post the check run
   contents: read
+  id-token: write   # upload the report to lumitrace.atdot.net for a linked HTML report
 
 jobs:
   test:
@@ -41,7 +42,9 @@ jobs:
         if: always()                        # report even when tests fail
 ```
 
-That's the whole integration: two steps plus a `permissions:` block.
+That's the whole integration: two steps plus a `permissions:` block. Drop
+`id-token: write` and you still get the PR check — just without the linked
+hosted report (nothing is uploaded anywhere).
 
 ## What you get
 
@@ -68,8 +71,9 @@ That's the whole integration: two steps plus a `permissions:` block.
 |---|---|---|
 | `output` | `lumitrace.json` | JSON path (must match `setup`'s `output`). |
 | `name` | `lumitrace` | Check run name shown on the PR. |
-| `endpoint` | _(empty)_ | Backend base URL to upload the JSON to. Empty = skip upload (no server needed). |
-| `audience` | `lumitrace-ci` | OIDC audience for the upload (only used when `endpoint` is set). |
+| `html` | `lumitrace.html` | HTML path (must match `setup`'s `html`); uploaded with the JSON. |
+| `endpoint` | `https://lumitrace.atdot.net` | Backend the report is uploaded to. Upload only happens when the workflow grants `id-token: write`; set to `""` to disable, or point at your own server. |
+| `audience` | `lumitrace-ci` | OIDC audience for the upload. |
 
 ## Notes
 
@@ -80,9 +84,10 @@ That's the whole integration: two steps plus a `permissions:` block.
   checkout works. (If you set `persist-credentials: false`, add `fetch-depth: 0`.)
 - **Fail-safe.** If lumitrace can't load on the runner's Ruby, `setup` warns and
   skips injection — your test step runs exactly as it would without this action.
-- **No backend or App needed.** `report` posts the check with the workflow
-  `GITHUB_TOKEN`. Set `endpoint` (and `permissions: id-token: write`) only when you
-  add a backend for the full HTML report.
+- **Hosted report is opt-in via `id-token: write`.** With that permission, `report`
+  uploads to `lumitrace.atdot.net` (OIDC-authenticated, no shared secret) and links
+  the check to the HTML report. Without it, nothing is uploaded — you just get the
+  check, posted with the workflow `GITHUB_TOKEN`. Any upload failure is non-fatal.
 - **Fork PRs.** `GITHUB_TOKEN` is read-only on PRs from forks, so the check can't
   be posted there until a GitHub App is added.
 

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -15,8 +15,11 @@ inputs:
     description: "Check run name shown on the PR."
     default: "lumitrace"
   endpoint:
-    description: "Backend base URL to upload the report to (e.g. https://lumitrace.atdot.net). Empty = skip upload (no server needed)."
-    default: ""
+    description: >-
+      Backend the report is uploaded to (for the linked HTML report). Defaults to
+      the hosted lumitrace.atdot.net. Upload only happens when the workflow grants
+      `id-token: write`; set to "" to disable, or point at your own server.
+    default: "https://lumitrace.atdot.net"
   audience:
     description: "OIDC audience for the upload (only used when endpoint is set)."
     default: "lumitrace-ci"
@@ -39,25 +42,27 @@ runs:
         HEAD_SHA="${{ github.event.pull_request.head.sha }}"
         [ -z "$HEAD_SHA" ] && HEAD_SHA="${{ github.sha }}"
 
-        # Optional upload to the backend, authenticated with the job's OIDC token
-        # (no shared secret). The server derives repo/sha/visibility from the OIDC
-        # claims; we send the trace JSON and the self-contained HTML, and use the
-        # returned view_url (a path) as the check's details link.
+        # Upload to the backend (default lumitrace.atdot.net) ONLY when an OIDC
+        # token is available — i.e. the workflow granted `id-token: write`. No
+        # token, no endpoint, or any failure just means no hosted-report link:
+        # this never fails the job (lumitrace never blocks CI).
         DETAILS=""
         ENDPOINT="${{ inputs.endpoint }}"
-        if [ -n "$ENDPOINT" ]; then
-          ENDPOINT="${ENDPOINT%/}"
+        ENDPOINT="${ENDPOINT%/}"
+        if [ -n "$ENDPOINT" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
           OIDC="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-                  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" \
-                  | ruby -rjson -e 'puts JSON.parse(STDIN.read)["value"]')"
-          HTML="${{ inputs.html }}"
-          html_field=()
-          [ -s "$HTML" ] && html_field=(-F "html=@${HTML}")
-          VIEW="$(curl -sS -X POST "${ENDPOINT}/api/v1/upload" \
-                  -H "Authorization: Bearer $OIDC" \
-                  -F "json=@${OUT}" "${html_field[@]}" \
-                  | ruby -rjson -e 'begin; puts JSON.parse(STDIN.read)["view_url"]; rescue; end')"
-          [ -n "$VIEW" ] && DETAILS="${ENDPOINT}${VIEW}"
+                  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" 2>/dev/null \
+                  | ruby -rjson -e 'begin; print JSON.parse(STDIN.read)["value"]; rescue; end' || true)"
+          if [ -n "$OIDC" ]; then
+            HTML="${{ inputs.html }}"
+            html_field=()
+            [ -s "$HTML" ] && html_field=(-F "html=@${HTML}")
+            VIEW="$(curl -sS -X POST "${ENDPOINT}/api/v1/upload" \
+                    -H "Authorization: Bearer $OIDC" \
+                    -F "json=@${OUT}" "${html_field[@]}" 2>/dev/null \
+                    | ruby -rjson -e 'begin; print JSON.parse(STDIN.read)["view_url"]; rescue; end' || true)"
+            [ -n "$VIEW" ] && DETAILS="${ENDPOINT}${VIEW}"
+          fi
         fi
 
         ruby "$GITHUB_ACTION_PATH/../build_check.rb" \

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -33,6 +33,14 @@ runs:
       run: |
         set -euo pipefail
 
+        # setup left lumitrace active in the env (RUBYOPT=-rlumitrace + LUMITRACE_*).
+        # Turn it OFF here: otherwise the ruby we run below (build_check.rb, the
+        # OIDC parsing) would re-trace and OVERWRITE the test's output file with an
+        # empty result before we read/upload it.
+        unset RUBYOPT RUBYLIB LUMITRACE_ENABLE LUMITRACE_JSON LUMITRACE_HTML \
+              LUMITRACE_TEXT LUMITRACE_GIT_DIFF LUMITRACE_RANGE LUMITRACE_ROOT \
+              LUMITRACE_COLLECT_MODE LUMITRACE_MAX_SAMPLES LUMITRACE_VERBOSE
+
         OUT="${{ inputs.output }}"
         if [ ! -s "$OUT" ]; then
           echo "lumitrace: no trace output at $OUT (diff had no traced lines?) — skipping check."

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -33,15 +33,34 @@ runs:
       run: |
         set -euo pipefail
 
+        OUT="${{ inputs.output }}"
+        HTML="${{ inputs.html }}"
+        # Capture the tracing config before we disable it (the merge below reuses it).
+        LUMI_LIB="$(cd "$GITHUB_ACTION_PATH/../.." && pwd)/lib"
+        LUMI_EXE="$(cd "$GITHUB_ACTION_PATH/../.." && pwd)/exe/lumitrace"
+        RESULTS_DIR="${LUMITRACE_RESULTS_DIR:-}"
+        ROOT="${LUMITRACE_ROOT:-$GITHUB_WORKSPACE}"
+        DIFF="${LUMITRACE_GIT_DIFF:-}"
+        MODE="${LUMITRACE_COLLECT_MODE:-last}"
+
         # setup left lumitrace active in the env (RUBYOPT=-rlumitrace + LUMITRACE_*).
-        # Turn it OFF here: otherwise the ruby we run below (build_check.rb, the
-        # OIDC parsing) would re-trace and OVERWRITE the test's output file with an
-        # empty result before we read/upload it.
+        # Turn it OFF so the ruby we run below (the merge, build_check, OIDC
+        # parsing) is not itself traced.
         unset RUBYOPT RUBYLIB LUMITRACE_ENABLE LUMITRACE_JSON LUMITRACE_HTML \
               LUMITRACE_TEXT LUMITRACE_GIT_DIFF LUMITRACE_RANGE LUMITRACE_ROOT \
-              LUMITRACE_COLLECT_MODE LUMITRACE_MAX_SAMPLES LUMITRACE_VERBOSE
+              LUMITRACE_COLLECT_MODE LUMITRACE_MAX_SAMPLES LUMITRACE_VERBOSE \
+              LUMITRACE_RESULTS_DIR LUMITRACE_RESULTS_PARENT_PID
 
-        OUT="${{ inputs.output }}"
+        # Finalize: combine every step's / every process's per-pid result files
+        # into one JSON + HTML. (Each test step wrote child files into the shared
+        # dir instead of finalizing, so splitting tests across steps still yields
+        # one report.) HTML range context is recomputed from the same diff.
+        if [ -n "$RESULTS_DIR" ] && ls "$RESULTS_DIR"/child_*.json >/dev/null 2>&1; then
+          ruby -I"$LUMI_LIB" "$LUMI_EXE" merge "$RESULTS_DIR" \
+            --json "$OUT" --html "$HTML" --root "$ROOT" --collect-mode "$MODE" \
+            ${DIFF:+--git-diff "$DIFF"} || true
+        fi
+
         if [ ! -s "$OUT" ]; then
           echo "lumitrace: no trace output at $OUT (diff had no traced lines?) — skipping check."
           exit 0

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -81,12 +81,21 @@ runs:
                   "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" 2>/dev/null \
                   | ruby -rjson -e 'begin; print JSON.parse(STDIN.read)["value"]; rescue; end' || true)"
           if [ -n "$OIDC" ]; then
-            HTML="${{ inputs.html }}"
+            # gzip the (highly compressible) JSON/HTML before upload — a big diff
+            # can produce MB-scale reports, and this is paid on every run. The
+            # server stores and serves the gzip bytes as-is.
+            tmp="${RUNNER_TEMP:-/tmp}"
+            json_up="$OUT"
+            gzip -c "$OUT" > "$tmp/lumitrace.json.gz" 2>/dev/null && json_up="$tmp/lumitrace.json.gz"
             html_field=()
-            [ -s "$HTML" ] && html_field=(-F "html=@${HTML}")
+            if [ -s "$HTML" ]; then
+              html_up="$HTML"
+              gzip -c "$HTML" > "$tmp/lumitrace.html.gz" 2>/dev/null && html_up="$tmp/lumitrace.html.gz"
+              html_field=(-F "html=@${html_up}")
+            fi
             VIEW="$(curl -sS -X POST "${ENDPOINT}/api/v1/upload" \
                     -H "Authorization: Bearer $OIDC" \
-                    -F "json=@${OUT}" "${html_field[@]}" 2>/dev/null \
+                    -F "json=@${json_up}" "${html_field[@]}" 2>/dev/null \
                     | ruby -rjson -e 'begin; print JSON.parse(STDIN.read)["view_url"]; rescue; end' || true)"
             [ -n "$VIEW" ] && DETAILS="${ENDPOINT}${VIEW}"
           fi

--- a/action/setup/action.yml
+++ b/action/setup/action.yml
@@ -68,6 +68,14 @@ runs:
             ;;
         esac
 
+        # One shared results dir for the whole job, with a sentinel parent pid
+        # (0) so EVERY traced process — across every test step, forks and spawns
+        # — just writes its own per-pid result file here and none tries to
+        # finalize. The report action merges them all. This is what lets a job
+        # split its tests across multiple `run:` steps and still get one report.
+        RESULTS_DIR="${RUNNER_TEMP:-/tmp}/lumitrace-results"
+        mkdir -p "$RESULTS_DIR"
+
         {
           echo "RUBYLIB=${LUMI_LIB}${RUBYLIB:+:$RUBYLIB}"
           echo "RUBYOPT=-rlumitrace ${RUBYOPT:-}"
@@ -77,6 +85,8 @@ runs:
           echo "LUMITRACE_ROOT=${{ github.workspace }}"
           echo "LUMITRACE_COLLECT_MODE=${{ inputs.collect-mode }}"
           echo "LUMITRACE_GIT_DIFF=${DIFF}"
+          echo "LUMITRACE_RESULTS_DIR=${RESULTS_DIR}"
+          echo "LUMITRACE_RESULTS_PARENT_PID=0"
         } >> "$GITHUB_ENV"
 
         echo "lumitrace enabled: mode=${{ inputs.collect-mode }} diff=${DIFF} out=${{ inputs.output }} lib=${LUMI_LIB}"

--- a/exe/lumitrace
+++ b/exe/lumitrace
@@ -4,6 +4,51 @@
 require "rbconfig"
 require_relative "../lib/lumitrace"
 
+if ARGV.first == "merge"
+  ARGV.shift
+  require "optparse"
+  opts = { collect_mode: "last" }
+  parser = OptionParser.new do |o|
+    o.banner = "usage: lumitrace merge [DIR] [--json PATH] [--html PATH] [--text PATH] " \
+               "[--root DIR] [--collect-mode M] [--max-samples N] [--git-diff MODE] [--range SPEC]"
+    o.on("--json PATH") { |v| opts[:json] = v }
+    o.on("--html PATH") { |v| opts[:html] = v }
+    o.on("--text PATH") { |v| opts[:text] = v }
+    o.on("--root DIR") { |v| opts[:root] = v }
+    o.on("--collect-mode M") { |v| opts[:collect_mode] = v }
+    o.on("--max-samples N", Integer) { |v| opts[:max_samples] = v }
+    o.on("--git-diff MODE") { |v| opts[:git_diff] = v }
+    o.on("--range SPEC") { |v| (opts[:ranges] ||= []) << v }
+  end
+  begin
+    parser.parse!(ARGV)
+  rescue OptionParser::ParseError => e
+    warn e.message
+    exit 1
+  end
+  dir = ARGV.shift || ENV["LUMITRACE_RESULTS_DIR"]
+  unless dir && Dir.exist?(dir)
+    warn "lumitrace merge: results dir not found: #{dir.inspect}"
+    exit 1
+  end
+  # Recompute the diff/range coverage for HTML/text context (same options the
+  # traced run used). JSON output needs no ranges.
+  ranges = Lumitrace.resolve_ranges_by_file(
+    opts[:ranges] || [],
+    git_diff_mode: opts[:git_diff],
+    git_diff_context: nil,
+    git_cmd: nil,
+    git_diff_no_untracked: false
+  )
+  Lumitrace.merge_results_dir(
+    dir,
+    json: opts[:json], html: opts[:html], text: opts[:text],
+    root: opts[:root], collect_mode: opts[:collect_mode],
+    max_samples: opts[:max_samples], ranges_by_file: ranges
+  )
+  exit 0
+end
+
 if ARGV.first == "help"
   ARGV.shift
   begin

--- a/lib/lumitrace.rb
+++ b/lib/lumitrace.rb
@@ -199,6 +199,46 @@ module Lumitrace
     File.join(@results_dir, "child_#{Process.pid}_#{ts}.json")
   end
 
+  # Combine all per-process child result files written into `dir` (by any number
+  # of processes / workflow steps that shared LUMITRACE_RESULTS_DIR) into final
+  # JSON / HTML / text outputs. Used by `lumitrace merge` so a job can split its
+  # tests across several steps and still produce one report. ranges_by_file (for
+  # HTML/text context) is recomputed from the same diff/range options.
+  def self.merge_results_dir(dir, json: nil, html: nil, text: nil, root: nil,
+                             collect_mode: nil, max_samples: nil, ranges_by_file: nil)
+    require_relative "lumitrace/record_instrument"
+    require_relative "lumitrace/generate_resulted_html"
+    root = File.expand_path(root || Dir.pwd)
+    collect_mode ||= "last"
+
+    events = RecordInstrument.merge_child_events([], dir, max_samples: max_samples,
+                                                 logger: (@verbose ? method(:verbose_log) : nil))
+
+    if json
+      json_path = File.expand_path(json, root)
+      RecordInstrument.dump_events_json(events, json_path)
+      notify_output_path("json", json_path)
+    end
+    if html
+      html_str = GenerateResultedHtml.render_all_from_normalized_events(
+        events, root: root, ranges_by_file: ranges_by_file,
+        collect_mode: collect_mode, max_samples: max_samples
+      )
+      html_path = File.expand_path(html, root)
+      File.write(html_path, html_str)
+      notify_output_path("html", html_path)
+    end
+    if text
+      text_str = GenerateResultedHtml.render_text_all_from_normalized_events(
+        events, root: root, ranges_by_file: ranges_by_file, tty: false
+      )
+      text_path = File.expand_path(text, root)
+      File.write(text_path, text_str)
+      notify_output_path("text", text_path)
+    end
+    events
+  end
+
 
   def self.serialize_ranges_by_file(ranges_by_file)
     return nil unless ranges_by_file

--- a/test/test_lumitrace.rb
+++ b/test/test_lumitrace.rb
@@ -234,6 +234,32 @@ class LumiTraceTest < Minitest::Test
     end
   end
 
+  # Multiple processes (e.g. tests split across workflow steps) each write a
+  # child_*.json into a shared results dir; merge_results_dir combines them into
+  # one JSON without clobbering.
+  def test_merge_results_dir_combines_child_files
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "child_111_0.json"), JSON.dump([
+        { file: "/x/a.rb", start_line: 1, start_col: 0, end_line: 1, end_col: 5,
+          kind: "expr", total: 2, last_value: { type: "Integer", preview: "2" }, types: { "Integer" => 2 } }
+      ]))
+      File.write(File.join(dir, "child_222_0.json"), JSON.dump([
+        { file: "/x/b.rb", start_line: 3, start_col: 0, end_line: 3, end_col: 5,
+          kind: "expr", total: 1, last_value: { type: "String", preview: "\"hi\"" }, types: { "String" => 1 } }
+      ]))
+
+      Dir.mktmpdir do |out|
+        json_path = File.join(out, "merged.json")
+        Lumitrace.merge_results_dir(dir, json: json_path, root: "/x", collect_mode: "last")
+        data = JSON.parse(File.read(json_path))
+        files = data["events"].map { |e| e["file"] }.sort
+        assert_equal ["/x/a.rb", "/x/b.rb"], files
+      end
+      # child files are consumed by the merge
+      assert_empty Dir.glob(File.join(dir, "child_*.json"))
+    end
+  end
+
   def test_merge_events_applies_max_samples
     events = [
       { file: "a.rb", start_line: 1, start_col: 0, end_line: 1, end_col: 1, sampled_values: [1, 2], total: 2 },


### PR DESCRIPTION
- **action/report: default endpoint to lumitrace.atdot.net, upload only with id-token**
- **action/report: unset lumitrace env before running ruby (don't clobber the output)**
- **Session results dir + `lumitrace merge`: combine traces across workflow steps**
- **action/report: gzip the JSON/HTML before upload (cuts upload bandwidth ~80-90%)**
