### PR TITLE
Drop sticky comment; JSON link in summary

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -21,10 +21,9 @@ name: test
 on: pull_request
 
 permissions:
-  checks: write          # post the check run
+  checks: write     # post the check run
   contents: read
-  id-token: write        # upload the report to lumitrace.atdot.net for a linked HTML report
-  pull-requests: write   # post a sticky PR comment (optional)
+  id-token: write   # upload the report to lumitrace.atdot.net for a linked HTML report
 
 jobs:
   test:
@@ -75,7 +74,6 @@ hosted report (nothing is uploaded anywhere).
 | `html` | `lumitrace.html` | HTML path (must match `setup`'s `html`); uploaded with the JSON. |
 | `endpoint` | `https://lumitrace.atdot.net` | Backend the report is uploaded to. Upload only happens when the workflow grants `id-token: write`; set to `""` to disable, or point at your own server. |
 | `audience` | `lumitrace-ci` | OIDC audience for the upload. |
-| `comment` | `true` | Post/update a sticky PR comment (summary + report/JSON links). Needs `pull-requests: write`; skipped silently otherwise. `false` to disable. |
 
 ## Notes
 
@@ -86,11 +84,9 @@ hosted report (nothing is uploaded anywhere).
   checkout works. (If you set `persist-credentials: false`, add `fetch-depth: 0`.)
 - **Fail-safe.** If lumitrace can't load on the runner's Ruby, `setup` warns and
   skips injection — your test step runs exactly as it would without this action.
-- **Sticky PR comment.** With `pull-requests: write`, `report` posts one comment
-  per PR (edited on later pushes) with the summary, recorded-value highlights, and
-  links to both the HTML report and the **raw JSON** — so you (or your own AI /
-  tooling) can pull the trace data. The JSON shape is documented by
-  `lumitrace schema --format json`.
+- **JSON for tooling / AI.** The check summary links the raw trace JSON
+  (`/r/<token>/data`) alongside the HTML report, so you (or your own AI / tooling)
+  can pull the data. Its shape is documented by `lumitrace schema --format json`.
 - **Hosted report is opt-in via `id-token: write`.** With that permission, `report`
   uploads to `lumitrace.atdot.net` (OIDC-authenticated, no shared secret) and links
   the check to the HTML report. Without it, nothing is uploaded — you just get the

--- a/action/build_check.rb
+++ b/action/build_check.rb
@@ -4,10 +4,7 @@
 # Convert a lumitrace JSON report into a GitHub "create a check run" payload,
 # printed as JSON on stdout.
 #
-#   build_check.rb <lumitrace.json> <head_sha> <root> [details_url] [comment_path]
-#
-# Prints the check-run payload as JSON on stdout. If comment_path is given, also
-# writes a sticky-PR-comment markdown body there (report + JSON-data links).
+#   build_check.rb <lumitrace.json> <head_sha> <root> [details_url]
 #
 # Annotation strategy (see the project plan): annotations are a *curated few*,
 # not every traced line. We surface uncovered changed lines first (most useful
@@ -22,9 +19,9 @@ MAX_ANNOTATIONS = 50
 # Cap value highlights (one per line) shown in the summary.
 HIGHLIGHT_LIMIT = 10
 
-json_path, head_sha, root, details_url, comment_path = ARGV
+json_path, head_sha, root, details_url = ARGV
 if json_path.nil? || head_sha.nil? || root.nil?
-  abort "usage: build_check.rb <lumitrace.json> <head_sha> <root> [details_url] [comment_path]"
+  abort "usage: build_check.rb <lumitrace.json> <head_sha> <root> [details_url]"
 end
 
 check_name = ENV.fetch("LUMITRACE_CHECK_NAME", "lumitrace")
@@ -114,7 +111,9 @@ unless highlights.empty?
   end
   summary << "- …and #{all_highlights.size - HIGHLIGHT_LIMIT} more\n" if highlights_truncated
 end
-summary << "\n[Full report ↗](#{details_url})\n" if details_url && !details_url.empty?
+if details_url && !details_url.empty?
+  summary << "\n[Full report ↗](#{details_url}) · [JSON for tooling/AI](#{details_url}/data)\n"
+end
 
 title =
   if uncovered.empty?
@@ -122,37 +121,6 @@ title =
   else
     "#{uncovered.size} uncovered · #{events.size} traced"
   end
-
-# Sticky PR comment body (optional). The hidden marker lets the action find and
-# update its own comment on later pushes. Surfaces both the human report and the
-# raw JSON URL so a reader (or their own AI/tooling) can pull the data.
-if comment_path
-  marker = "<!-- lumitrace-report -->"
-  comment = +"#{marker}\n### 🔦 Lumitrace — #{title}\n\n"
-  unless coverage.empty?
-    comment << "| File | Covered | % |\n|---|---|---|\n"
-    coverage.each do |c|
-      comment << "| `#{relativize.call(c["file"])}` | " \
-                 "#{c["covered_lines"]}/#{c["total_lines"]} | #{c["coverage_percent"]}% |\n"
-    end
-  end
-  comment << "\n⚠️ #{uncovered.size} changed line(s) never executed.\n" unless uncovered.empty?
-  unless highlights.empty?
-    comment << "\n<details><summary>Recorded values</summary>\n\n"
-    highlights.each do |e|
-      loc = "#{relativize.call(e["file"])}:#{e["start_line"]}"
-      name = e["name"] ? "`#{e["name"]}` " : ""
-      comment << "- `#{loc}` #{name}→ #{value_of.call(e)}\n"
-    end
-    comment << "- …and #{all_highlights.size - HIGHLIGHT_LIMIT} more\n" if highlights_truncated
-    comment << "\n</details>\n"
-  end
-  if details_url && !details_url.empty?
-    comment << "\n**[Full report ↗](#{details_url})**"
-    comment << " · [JSON for tooling/AI](#{details_url}/data)\n"
-  end
-  File.write(comment_path, comment)
-end
 
 payload = {
   "name" => check_name,

--- a/action/report/action.yml
+++ b/action/report/action.yml
@@ -23,11 +23,6 @@ inputs:
   audience:
     description: "OIDC audience for the upload (only used when endpoint is set)."
     default: "lumitrace-ci"
-  comment:
-    description: >-
-      Post (and update) a sticky PR comment with the summary + report/JSON links.
-      Needs `permissions: pull-requests: write`; skipped silently otherwise. Set "false" to disable.
-    default: "true"
 runs:
   using: composite
   steps:
@@ -106,29 +101,9 @@ runs:
           fi
         fi
 
-        COMMENT_MD="$RUNNER_TEMP/lumitrace-comment.md"
         ruby "$GITHUB_ACTION_PATH/../build_check.rb" \
-          "$OUT" "$HEAD_SHA" "${{ github.workspace }}" "$DETAILS" "$COMMENT_MD" \
-          > "$RUNNER_TEMP/lumitrace-check.json"
+          "$OUT" "$HEAD_SHA" "${{ github.workspace }}" "$DETAILS" > "$RUNNER_TEMP/lumitrace-check.json"
 
         gh api "repos/${{ github.repository }}/check-runs" \
           --input "$RUNNER_TEMP/lumitrace-check.json" --silent
         echo "lumitrace: posted check run '${{ inputs.name }}' for ${HEAD_SHA}"
-
-        # Sticky PR comment: one comment per PR, edited on later pushes. Found by
-        # a hidden marker. Non-fatal — needs pull-requests: write, skipped otherwise.
-        PR_NUMBER="${{ github.event.pull_request.number }}"
-        if [ "${{ inputs.comment }}" = "true" ] && [ -n "$PR_NUMBER" ] && [ -s "$COMMENT_MD" ]; then
-          repo="${{ github.repository }}"
-          existing="$(gh api "repos/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '.[] | select(.body | contains("<!-- lumitrace-report -->")) | .id' 2>/dev/null | head -1 || true)"
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/${repo}/issues/comments/${existing}" -F body=@"$COMMENT_MD" --silent 2>/dev/null \
-              && echo "lumitrace: updated PR comment" \
-              || echo "::warning title=lumitrace::could not update PR comment (need permissions: pull-requests: write?)"
-          else
-            gh api "repos/${repo}/issues/${PR_NUMBER}/comments" -F body=@"$COMMENT_MD" --silent 2>/dev/null \
-              && echo "lumitrace: posted PR comment" \
-              || echo "::warning title=lumitrace::could not post PR comment (need permissions: pull-requests: write?)"
-          fi
-        fi


### PR DESCRIPTION
The sticky comment was too noisy for this content, and an opt-in toggle would
go unused. Remove it (and the pull-requests: write requirement). The raw-JSON
link for tooling/AI now lives in the check summary next to the report link; the
title already shows uncovered counts ("N uncovered · M traced").
